### PR TITLE
Add promotion link for build cache training

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -1,5 +1,7 @@
 = Executing Gradle builds on Travis CI
 
+TIP: Top engineering teams using Travis CI have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. https://gradle.com/training/build-cache-deep-dive/?bid=guides-execute-travisci[Register here] for our Build Cache training session to learn how your team can achieve similar results.
+
 Building Gradle projects doesn't stop with the developer's machine.
 https://en.wikipedia.org/wiki/Continuous_integration[Continuous Integration] (CI) has been a long-established practice for running a build for every single change committed to version control to tighten the feedback loop.
 


### PR DESCRIPTION
https://github.com/gradle/marketing/issues/1230